### PR TITLE
[#57] 공통 응답 구조 + 에러 핸들러 구현

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -40,4 +40,7 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	testLogging {
+		events 'passed', 'failed', 'skipped'
+	}
 }

--- a/server/src/main/java/com/lectureq/server/global/error/BusinessException.java
+++ b/server/src/main/java/com/lectureq/server/global/error/BusinessException.java
@@ -1,0 +1,19 @@
+package com.lectureq.server.global.error;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/server/src/main/java/com/lectureq/server/global/error/ErrorCode.java
+++ b/server/src/main/java/com/lectureq/server/global/error/ErrorCode.java
@@ -1,0 +1,21 @@
+package com.lectureq.server.global.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    BAD_REQUEST(400, "잘못된 요청입니다"),
+    UNAUTHORIZED(401, "인증이 필요합니다"),
+    FORBIDDEN(403, "접근 권한이 없습니다"),
+    NOT_FOUND(404, "요청한 리소스가 존재하지 않습니다"),
+    CONFLICT(409, "리소스 상태가 충돌합니다"),
+    GONE(410, "요청한 리소스가 더 이상 존재하지 않습니다"),
+    TOO_MANY_REQUESTS(429, "요청이 너무 많습니다"),
+    INTERNAL_SERVER_ERROR(500, "서버 내부 오류가 발생했습니다");
+
+    private final int status;
+    private final String message;
+}

--- a/server/src/main/java/com/lectureq/server/global/error/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/lectureq/server/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,34 @@
+package com.lectureq.server.global.error;
+
+import com.lectureq.server.global.response.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ApiResponse.error(errorCode.getStatus(), e.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleValidationException(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getFieldErrors().get(0).getDefaultMessage();
+        return ResponseEntity.badRequest()
+                .body(ApiResponse.error(400, message));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        log.error("Unexpected error", e);
+        return ResponseEntity.internalServerError()
+                .body(ApiResponse.error(500, "서버 내부 오류가 발생했습니다"));
+    }
+}

--- a/server/src/main/java/com/lectureq/server/global/response/ApiResponse.java
+++ b/server/src/main/java/com/lectureq/server/global/response/ApiResponse.java
@@ -1,0 +1,39 @@
+package com.lectureq.server.global.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResponse<T> {
+
+    private final int status;
+    private final String message;
+    private final T data;
+
+    private ApiResponse(int status, String message, T data) {
+        this.status = status;
+        this.message = message;
+        this.data = data;
+    }
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(200, "성공", data);
+    }
+
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return new ApiResponse<>(200, message, data);
+    }
+
+    public static ApiResponse<Void> successMessage(String message) {
+        return new ApiResponse<>(200, message, null);
+    }
+
+    public static <T> ApiResponse<T> success(int status, String message, T data) {
+        return new ApiResponse<>(status, message, data);
+    }
+
+    public static ApiResponse<Void> error(int status, String message) {
+        return new ApiResponse<>(status, message, null);
+    }
+}

--- a/server/src/test/java/com/lectureq/server/global/error/GlobalExceptionHandlerTest.java
+++ b/server/src/test/java/com/lectureq/server/global/error/GlobalExceptionHandlerTest.java
@@ -1,0 +1,92 @@
+package com.lectureq.server.global.error;
+
+import com.lectureq.server.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest
+@Import({GlobalExceptionHandler.class, GlobalExceptionHandlerTest.TestController.class})
+@WithMockUser
+class GlobalExceptionHandlerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void businessException_default_message() throws Exception {
+        mockMvc.perform(get("/test/business-default"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.message").value("요청한 리소스가 존재하지 않습니다"));
+    }
+
+    @Test
+    void businessException_custom_message() throws Exception {
+        mockMvc.perform(get("/test/business-custom"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.status").value(409))
+                .andExpect(jsonPath("$.message").value("분석이 진행 중인 녹음은 삭제할 수 없습니다."));
+    }
+
+    @Test
+    void validationException() throws Exception {
+        mockMvc.perform(post("/test/validation")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"title\": \"\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value("제목은 필수입니다"));
+    }
+
+    @Test
+    void unexpectedException() throws Exception {
+        mockMvc.perform(get("/test/unexpected"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.status").value(500))
+                .andExpect(jsonPath("$.message").value("서버 내부 오류가 발생했습니다"));
+    }
+
+    @RestController
+    static class TestController {
+
+        @GetMapping("/test/business-default")
+        public ApiResponse<Void> businessDefault() {
+            throw new BusinessException(ErrorCode.NOT_FOUND);
+        }
+
+        @GetMapping("/test/business-custom")
+        public ApiResponse<Void> businessCustom() {
+            throw new BusinessException(ErrorCode.CONFLICT, "분석이 진행 중인 녹음은 삭제할 수 없습니다.");
+        }
+
+        @PostMapping("/test/validation")
+        public ApiResponse<Void> validation(@Valid @RequestBody TestRequest request) {
+            return ApiResponse.successMessage("성공");
+        }
+
+        @GetMapping("/test/unexpected")
+        public ApiResponse<Void> unexpected() {
+            throw new RuntimeException("unexpected error");
+        }
+
+        record TestRequest(@NotBlank(message = "제목은 필수입니다") String title) {}
+    }
+}

--- a/server/src/test/java/com/lectureq/server/global/response/ApiResponseTest.java
+++ b/server/src/test/java/com/lectureq/server/global/response/ApiResponseTest.java
@@ -1,0 +1,67 @@
+package com.lectureq.server.global.response;
+
+import tools.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ApiResponseTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void success_with_data() {
+        ApiResponse<Integer> response = ApiResponse.success(42);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getMessage()).isEqualTo("성공");
+        assertThat(response.getData()).isEqualTo(42);
+    }
+
+    @Test
+    void success_with_message_only() {
+        ApiResponse<Void> response = ApiResponse.successMessage("삭제 성공");
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getMessage()).isEqualTo("삭제 성공");
+        assertThat(response.getData()).isNull();
+    }
+
+    @Test
+    void success_with_message_and_data() {
+        ApiResponse<Integer> response = ApiResponse.success("조회 성공", 42);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getMessage()).isEqualTo("조회 성공");
+        assertThat(response.getData()).isEqualTo(42);
+    }
+
+    @Test
+    void success_with_custom_status() {
+        ApiResponse<String> response = ApiResponse.success(201, "생성 성공", "new-id");
+
+        assertThat(response.getStatus()).isEqualTo(201);
+        assertThat(response.getMessage()).isEqualTo("생성 성공");
+        assertThat(response.getData()).isEqualTo("new-id");
+    }
+
+    @Test
+    void data_included_in_json() throws Exception {
+        ApiResponse<Integer> response = ApiResponse.success(42);
+
+        String json = objectMapper.writeValueAsString(response);
+
+        assertThat(json).contains("\"data\":42");
+    }
+
+    @Test
+    void null_data_excluded_from_json() throws Exception {
+        ApiResponse<Void> response = ApiResponse.successMessage("삭제 성공");
+
+        String json = objectMapper.writeValueAsString(response);
+
+        assertThat(json).contains("\"status\"");
+        assertThat(json).contains("\"message\"");
+        assertThat(json).doesNotContain("\"data\"");
+    }
+}


### PR DESCRIPTION
## 변경 사항
- ApiResponse<T> 공통 응답 클래스
- GlobalExceptionHandler + CustomException
- ErrorCode enum (8개 에러 코드)

## 테스트
- 정상 응답 구조 확인
- 각 에러 코드별 응답 확인

closes #57