### PR TITLE
[#60] GitHub Actions CI 파이프라인 구축

### DIFF
--- a/.github/workflows/be-ci.yml
+++ b/.github/workflows/be-ci.yml
@@ -1,0 +1,43 @@
+name: BE CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths: ['server/**']
+  push:
+    branches: [main]
+    paths: ['server/**']
+
+defaults:
+  run:
+    working-directory: server
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('server/**/*.gradle*', 'server/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build and Test
+        run: ./gradlew build

--- a/.github/workflows/fe-ci.yml
+++ b/.github/workflows/fe-ci.yml
@@ -1,0 +1,37 @@
+name: FE CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths: ['client/**']
+  push:
+    branches: [main]
+    paths: ['client/**']
+
+defaults:
+  run:
+    working-directory: client
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: client/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	systemProperty 'spring.profiles.active', 'test'
 	testLogging {
 		events 'passed', 'failed', 'skipped'
 	}


### PR DESCRIPTION
## 변경 사항
- BE CI 워크플로우 (be-ci.yml) — Java 21 + Gradle build + test (H2)
- FE CI 워크플로우 (fe-ci.yml) — Node.js 22 + lint + build
- build.gradle 테스트 프로필 설정 (spring.profiles.active=test)
- BE/FE paths 필터로 변경된 쪽만 CI 실행

## 테스트
- PR 생성 시 CI 자동 실행 확인