### PR TITLE
[#61] 카카오 소셜 로그인 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -347,3 +347,6 @@ gradle-app.setting
 *.hprof
 
 # End of https://www.toptal.com/developers/gitignore/api/macos,visualstudiocode,java,intellij+all,react,gradle,node
+
+# Local config with secrets
+application-local.yml

--- a/server/src/main/java/com/lectureq/server/analysis/entity/Analysis.java
+++ b/server/src/main/java/com/lectureq/server/analysis/entity/Analysis.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "analysis")
+@Table(name = "analyses")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Analysis extends BaseEntity {

--- a/server/src/main/java/com/lectureq/server/auth/controller/AuthController.java
+++ b/server/src/main/java/com/lectureq/server/auth/controller/AuthController.java
@@ -1,0 +1,53 @@
+package com.lectureq.server.auth.controller;
+
+import com.lectureq.server.auth.dto.LoginRequest;
+import com.lectureq.server.auth.dto.LoginResponse;
+import com.lectureq.server.auth.service.AuthService;
+import com.lectureq.server.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @Value("${cookie.secure}")
+    private boolean cookieSecure;
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<LoginResponse>> login(@RequestBody @Valid LoginRequest request) {
+        AuthService.LoginResult result = authService.login(request.getCode());
+
+        ResponseCookie accessTokenCookie = ResponseCookie.from("accessToken", result.accessToken())
+                .httpOnly(true)
+                .secure(cookieSecure)
+                .sameSite("Lax")
+                .path("/")
+                .maxAge(1800)
+                .build();
+
+        ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", result.refreshToken())
+                .httpOnly(true)
+                .secure(cookieSecure)
+                .sameSite("Lax")
+                .path("/api/v1/auth")
+                .maxAge(1209600)
+                .build();
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
+                .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
+                .body(ApiResponse.success("로그인 성공", result.loginResponse()));
+    }
+}

--- a/server/src/main/java/com/lectureq/server/auth/controller/AuthController.java
+++ b/server/src/main/java/com/lectureq/server/auth/controller/AuthController.java
@@ -20,34 +20,53 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AuthController {
 
+    private static final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
+    private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+    private static final String ACCESS_TOKEN_COOKIE_PATH = "/";
+    private static final String REFRESH_TOKEN_COOKIE_PATH = "/api/v1/auth";
+    private static final String COOKIE_SAME_SITE = "Lax";
+
     private final AuthService authService;
 
     @Value("${cookie.secure}")
     private boolean cookieSecure;
 
+    @Value("${jwt.access-expiration}")
+    private long accessTokenExpirationMs;
+
+    @Value("${jwt.refresh-expiration}")
+    private long refreshTokenExpirationMs;
+
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<LoginResponse>> login(@RequestBody @Valid LoginRequest request) {
         AuthService.LoginResult result = authService.login(request.getCode());
 
-        ResponseCookie accessTokenCookie = ResponseCookie.from("accessToken", result.accessToken())
-                .httpOnly(true)
-                .secure(cookieSecure)
-                .sameSite("Lax")
-                .path("/")
-                .maxAge(1800)
-                .build();
-
-        ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", result.refreshToken())
-                .httpOnly(true)
-                .secure(cookieSecure)
-                .sameSite("Lax")
-                .path("/api/v1/auth")
-                .maxAge(1209600)
-                .build();
+        ResponseCookie accessTokenCookie = buildAccessTokenCookie(result.accessToken());
+        ResponseCookie refreshTokenCookie = buildRefreshTokenCookie(result.refreshToken());
 
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
                 .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
                 .body(ApiResponse.success("로그인 성공", result.loginResponse()));
+    }
+
+    private ResponseCookie buildAccessTokenCookie(String value) {
+        return ResponseCookie.from(ACCESS_TOKEN_COOKIE_NAME, value)
+                .httpOnly(true)
+                .secure(cookieSecure)
+                .sameSite(COOKIE_SAME_SITE)
+                .path(ACCESS_TOKEN_COOKIE_PATH)
+                .maxAge(accessTokenExpirationMs / 1000)
+                .build();
+    }
+
+    private ResponseCookie buildRefreshTokenCookie(String value) {
+        return ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, value)
+                .httpOnly(true)
+                .secure(cookieSecure)
+                .sameSite(COOKIE_SAME_SITE)
+                .path(REFRESH_TOKEN_COOKIE_PATH)
+                .maxAge(refreshTokenExpirationMs / 1000)
+                .build();
     }
 }

--- a/server/src/main/java/com/lectureq/server/auth/dto/LoginRequest.java
+++ b/server/src/main/java/com/lectureq/server/auth/dto/LoginRequest.java
@@ -1,0 +1,13 @@
+package com.lectureq.server.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginRequest {
+
+    @NotBlank(message = "인가 코드는 필수입니다")
+    private String code;
+}

--- a/server/src/main/java/com/lectureq/server/auth/dto/LoginResponse.java
+++ b/server/src/main/java/com/lectureq/server/auth/dto/LoginResponse.java
@@ -1,0 +1,27 @@
+package com.lectureq.server.auth.dto;
+
+import com.lectureq.server.user.entity.User;
+import lombok.Getter;
+
+@Getter
+public class LoginResponse {
+
+    private final UserInfo user;
+
+    public LoginResponse(User user) {
+        this.user = new UserInfo(user);
+    }
+
+    @Getter
+    public static class UserInfo {
+        private final Long id;
+        private final String nickname;
+        private final String profileImage;
+
+        public UserInfo(User user) {
+            this.id = user.getId();
+            this.nickname = user.getNickname();
+            this.profileImage = user.getProfileImage();
+        }
+    }
+}

--- a/server/src/main/java/com/lectureq/server/auth/dto/LoginResponse.java
+++ b/server/src/main/java/com/lectureq/server/auth/dto/LoginResponse.java
@@ -16,6 +16,7 @@ public class LoginResponse {
     public static class UserInfo {
         private final Long id;
         private final String nickname;
+        /** 카카오 프로필 이미지 URL (kakao_account.profile.profile_image_url, base64 아님) */
         private final String profileImage;
 
         public UserInfo(User user) {

--- a/server/src/main/java/com/lectureq/server/auth/entity/RefreshToken.java
+++ b/server/src/main/java/com/lectureq/server/auth/entity/RefreshToken.java
@@ -23,7 +23,7 @@ public class RefreshToken {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(unique = true, nullable = false, length = 255)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String token;
 
     @Column(nullable = false)

--- a/server/src/main/java/com/lectureq/server/auth/entity/RefreshToken.java
+++ b/server/src/main/java/com/lectureq/server/auth/entity/RefreshToken.java
@@ -6,13 +6,16 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "refresh_token")
+@Table(name = "refresh_tokens")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class RefreshToken {
 
     @Id
@@ -23,19 +26,15 @@ public class RefreshToken {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(nullable = false, columnDefinition = "TEXT")
+    @Column(nullable = false, length = 500)
     private String token;
 
     @Column(nullable = false)
     private LocalDateTime expiredAt;
 
+    @CreatedDate
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
-
-    @PrePersist
-    protected void onCreate() {
-        this.createdAt = LocalDateTime.now();
-    }
 
     @Builder
     public RefreshToken(User user, String token, LocalDateTime expiredAt) {

--- a/server/src/main/java/com/lectureq/server/auth/repository/RefreshTokenRepository.java
+++ b/server/src/main/java/com/lectureq/server/auth/repository/RefreshTokenRepository.java
@@ -1,7 +1,9 @@
 package com.lectureq.server.auth.repository;
 
 import com.lectureq.server.auth.entity.RefreshToken;
+import com.lectureq.server.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    void deleteByUser(User user);
 }

--- a/server/src/main/java/com/lectureq/server/auth/service/AuthService.java
+++ b/server/src/main/java/com/lectureq/server/auth/service/AuthService.java
@@ -1,0 +1,69 @@
+package com.lectureq.server.auth.service;
+
+import com.lectureq.server.auth.dto.LoginResponse;
+import com.lectureq.server.auth.entity.RefreshToken;
+import com.lectureq.server.auth.repository.RefreshTokenRepository;
+import com.lectureq.server.global.infra.kakao.KakaoClient;
+import com.lectureq.server.global.infra.kakao.KakaoTokenResponse;
+import com.lectureq.server.global.infra.kakao.KakaoUserResponse;
+import com.lectureq.server.global.jwt.JwtProvider;
+import com.lectureq.server.user.entity.User;
+import com.lectureq.server.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final KakaoClient kakaoClient;
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtProvider jwtProvider;
+
+    @Transactional
+    public LoginResult login(String code) {
+        // 1. 카카오 토큰 발급
+        KakaoTokenResponse tokenResponse = kakaoClient.getToken(code);
+
+        // 2. 카카오 사용자 정보 조회
+        KakaoUserResponse userResponse = kakaoClient.getUserInfo(tokenResponse.getAccessToken());
+
+        // 3. 회원 확인/가입
+        String kakaoId = String.valueOf(userResponse.getId());
+        User user = userRepository.findByKakaoId(kakaoId)
+                .map(existingUser -> {
+                    existingUser.updateProfile(
+                            userResponse.getNickname(),
+                            userResponse.getProfileImageUrl());
+                    return existingUser;
+                })
+                .orElseGet(() -> userRepository.save(User.builder()
+                        .kakaoId(kakaoId)
+                        .nickname(userResponse.getNickname())
+                        .profileImage(userResponse.getProfileImageUrl())
+                        .build()));
+
+        // 4. 기존 RefreshToken 삭제
+        refreshTokenRepository.deleteByUser(user);
+
+        // 5-6. JWT 생성
+        String accessToken = jwtProvider.createAccessToken(user.getId());
+        String refreshToken = jwtProvider.createRefreshToken(user.getId());
+
+        // 7. RefreshToken DB 저장
+        refreshTokenRepository.save(RefreshToken.builder()
+                .user(user)
+                .token(refreshToken)
+                .expiredAt(LocalDateTime.now().plusDays(14))
+                .build());
+
+        // 8. 응답
+        return new LoginResult(accessToken, refreshToken, new LoginResponse(user));
+    }
+
+    public record LoginResult(String accessToken, String refreshToken, LoginResponse loginResponse) {}
+}

--- a/server/src/main/java/com/lectureq/server/auth/service/AuthService.java
+++ b/server/src/main/java/com/lectureq/server/auth/service/AuthService.java
@@ -10,10 +10,12 @@ import com.lectureq.server.global.jwt.JwtProvider;
 import com.lectureq.server.user.entity.User;
 import com.lectureq.server.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +25,9 @@ public class AuthService {
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtProvider jwtProvider;
+
+    @Value("${jwt.refresh-expiration}")
+    private long refreshTokenExpirationMs;
 
     @Transactional
     public LoginResult login(String code) {
@@ -34,18 +39,19 @@ public class AuthService {
 
         // 3. 회원 확인/가입
         String kakaoId = String.valueOf(userResponse.getId());
-        User user = userRepository.findByKakaoId(kakaoId)
-                .map(existingUser -> {
-                    existingUser.updateProfile(
-                            userResponse.getNickname(),
-                            userResponse.getProfileImageUrl());
-                    return existingUser;
-                })
-                .orElseGet(() -> userRepository.save(User.builder()
-                        .kakaoId(kakaoId)
-                        .nickname(userResponse.getNickname())
-                        .profileImage(userResponse.getProfileImageUrl())
-                        .build()));
+        Optional<User> existing = userRepository.findByKakaoId(kakaoId);
+
+        User user;
+        if (existing.isPresent()) {
+            user = existing.get();
+            user.updateProfile(userResponse.getNickname(), userResponse.getProfileImageUrl());
+        } else {
+            user = userRepository.save(User.builder()
+                    .kakaoId(kakaoId)
+                    .nickname(userResponse.getNickname())
+                    .profileImage(userResponse.getProfileImageUrl())
+                    .build());
+        }
 
         // 4. 기존 RefreshToken 삭제
         refreshTokenRepository.deleteByUser(user);
@@ -58,7 +64,7 @@ public class AuthService {
         refreshTokenRepository.save(RefreshToken.builder()
                 .user(user)
                 .token(refreshToken)
-                .expiredAt(LocalDateTime.now().plusDays(14))
+                .expiredAt(LocalDateTime.now().plusNanos(refreshTokenExpirationMs * 1_000_000))
                 .build());
 
         // 8. 응답

--- a/server/src/main/java/com/lectureq/server/global/config/SecurityConfig.java
+++ b/server/src/main/java/com/lectureq/server/global/config/SecurityConfig.java
@@ -1,0 +1,26 @@
+package com.lectureq.server.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/v1/auth/login", "/api/v1/auth/refresh", "/api/v1/auth/logout").permitAll()
+                        .anyRequest().authenticated());
+
+        return http.build();
+    }
+}

--- a/server/src/main/java/com/lectureq/server/global/infra/kakao/KakaoClient.java
+++ b/server/src/main/java/com/lectureq/server/global/infra/kakao/KakaoClient.java
@@ -1,0 +1,78 @@
+package com.lectureq.server.global.infra.kakao;
+
+import com.lectureq.server.global.error.BusinessException;
+import com.lectureq.server.global.error.ErrorCode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
+
+import java.time.Duration;
+
+@Component
+public class KakaoClient {
+
+    private final RestClient restClient;
+    private final String clientId;
+    private final String clientSecret;
+    private final String redirectUri;
+
+    public KakaoClient(
+            @Value("${kakao.client-id}") String clientId,
+            @Value("${kakao.client-secret}") String clientSecret,
+            @Value("${kakao.redirect-uri}") String redirectUri) {
+        this.restClient = RestClient.builder()
+                .requestFactory(clientHttpRequestFactory())
+                .build();
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.redirectUri = redirectUri;
+    }
+
+    private org.springframework.http.client.ClientHttpRequestFactory clientHttpRequestFactory() {
+        org.springframework.http.client.SimpleClientHttpRequestFactory factory =
+                new org.springframework.http.client.SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(Duration.ofSeconds(5));
+        factory.setReadTimeout(Duration.ofSeconds(10));
+        return factory;
+    }
+
+    public KakaoTokenResponse getToken(String code) {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", clientId);
+        params.add("redirect_uri", redirectUri);
+        params.add("code", code);
+        params.add("client_secret", clientSecret);
+
+        try {
+            return restClient.post()
+                    .uri("https://kauth.kakao.com/oauth/token")
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(params)
+                    .retrieve()
+                    .body(KakaoTokenResponse.class);
+        } catch (RestClientResponseException e) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED, "카카오 인가 코드가 유효하지 않습니다.");
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "카카오 서버 연동 중 오류가 발생했습니다.");
+        }
+    }
+
+    public KakaoUserResponse getUserInfo(String accessToken) {
+        try {
+            return restClient.get()
+                    .uri("https://kapi.kakao.com/v2/user/me")
+                    .header("Authorization", "Bearer " + accessToken)
+                    .retrieve()
+                    .body(KakaoUserResponse.class);
+        } catch (RestClientResponseException e) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED, "카카오 인가 코드가 유효하지 않습니다.");
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "카카오 서버 연동 중 오류가 발생했습니다.");
+        }
+    }
+}

--- a/server/src/main/java/com/lectureq/server/global/infra/kakao/KakaoClient.java
+++ b/server/src/main/java/com/lectureq/server/global/infra/kakao/KakaoClient.java
@@ -4,6 +4,8 @@ import com.lectureq.server.global.error.BusinessException;
 import com.lectureq.server.global.error.ErrorCode;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -32,9 +34,8 @@ public class KakaoClient {
         this.redirectUri = redirectUri;
     }
 
-    private org.springframework.http.client.ClientHttpRequestFactory clientHttpRequestFactory() {
-        org.springframework.http.client.SimpleClientHttpRequestFactory factory =
-                new org.springframework.http.client.SimpleClientHttpRequestFactory();
+    private ClientHttpRequestFactory clientHttpRequestFactory() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
         factory.setConnectTimeout(Duration.ofSeconds(5));
         factory.setReadTimeout(Duration.ofSeconds(10));
         return factory;

--- a/server/src/main/java/com/lectureq/server/global/infra/kakao/KakaoTokenResponse.java
+++ b/server/src/main/java/com/lectureq/server/global/infra/kakao/KakaoTokenResponse.java
@@ -1,0 +1,25 @@
+package com.lectureq.server.global.infra.kakao;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoTokenResponse {
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("expires_in")
+    private Integer expiresIn;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("refresh_token_expires_in")
+    private Integer refreshTokenExpiresIn;
+}

--- a/server/src/main/java/com/lectureq/server/global/infra/kakao/KakaoUserResponse.java
+++ b/server/src/main/java/com/lectureq/server/global/infra/kakao/KakaoUserResponse.java
@@ -1,0 +1,44 @@
+package com.lectureq.server.global.infra.kakao;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoUserResponse {
+
+    private Long id;
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    @Getter
+    @NoArgsConstructor
+    public static class KakaoAccount {
+        private Profile profile;
+
+        @Getter
+        @NoArgsConstructor
+        public static class Profile {
+            private String nickname;
+
+            @JsonProperty("profile_image_url")
+            private String profileImageUrl;
+        }
+    }
+
+    public String getNickname() {
+        if (kakaoAccount != null && kakaoAccount.getProfile() != null) {
+            return kakaoAccount.getProfile().getNickname();
+        }
+        return null;
+    }
+
+    public String getProfileImageUrl() {
+        if (kakaoAccount != null && kakaoAccount.getProfile() != null) {
+            return kakaoAccount.getProfile().getProfileImageUrl();
+        }
+        return null;
+    }
+}

--- a/server/src/main/java/com/lectureq/server/global/jwt/JwtProvider.java
+++ b/server/src/main/java/com/lectureq/server/global/jwt/JwtProvider.java
@@ -1,0 +1,47 @@
+package com.lectureq.server.global.jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+public class JwtProvider {
+
+    private final SecretKey secretKey;
+    private final long accessExpiration;
+    private final long refreshExpiration;
+
+    public JwtProvider(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.access-expiration}") long accessExpiration,
+            @Value("${jwt.refresh-expiration}") long refreshExpiration) {
+        this.secretKey = Keys.hmacShaKeyFor(Base64.getDecoder().decode(secret));
+        this.accessExpiration = accessExpiration;
+        this.refreshExpiration = refreshExpiration;
+    }
+
+    public String createAccessToken(Long userId) {
+        return createToken(userId, accessExpiration);
+    }
+
+    public String createRefreshToken(Long userId) {
+        return createToken(userId, refreshExpiration);
+    }
+
+    private String createToken(Long userId, long expiration) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + expiration);
+
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .issuedAt(now)
+                .expiration(expiryDate)
+                .signWith(secretKey)
+                .compact();
+    }
+}

--- a/server/src/main/java/com/lectureq/server/question/entity/Question.java
+++ b/server/src/main/java/com/lectureq/server/question/entity/Question.java
@@ -6,13 +6,16 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "question")
+@Table(name = "questions")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class Question {
 
     @Id
@@ -29,13 +32,9 @@ public class Question {
     @Column(nullable = false)
     private Integer orderNum;
 
+    @CreatedDate
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
-
-    @PrePersist
-    protected void onCreate() {
-        this.createdAt = LocalDateTime.now();
-    }
 
     @Builder
     public Question(Analysis analysis, String content, Integer orderNum) {

--- a/server/src/main/java/com/lectureq/server/recording/entity/Recording.java
+++ b/server/src/main/java/com/lectureq/server/recording/entity/Recording.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "recording")
+@Table(name = "recordings")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Recording extends BaseEntity {

--- a/server/src/main/java/com/lectureq/server/user/entity/User.java
+++ b/server/src/main/java/com/lectureq/server/user/entity/User.java
@@ -26,6 +26,11 @@ public class User extends BaseEntity {
     @Column(columnDefinition = "TEXT")
     private String profileImage;
 
+    public void updateProfile(String nickname, String profileImage) {
+        this.nickname = nickname;
+        this.profileImage = profileImage;
+    }
+
     @Builder
     public User(String kakaoId, String nickname, String profileImage) {
         this.kakaoId = kakaoId;

--- a/server/src/main/java/com/lectureq/server/user/repository/UserRepository.java
+++ b/server/src/main/java/com/lectureq/server/user/repository/UserRepository.java
@@ -3,5 +3,8 @@ package com.lectureq.server.user.repository;
 import com.lectureq.server.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByKakaoId(String kakaoId);
 }

--- a/server/src/main/resources/application-local.yml.example
+++ b/server/src/main/resources/application-local.yml.example
@@ -5,7 +5,7 @@ spring:
   datasource:
     url: jdbc:mysql://localhost:3306/lectureq?useSSL=false&allowPublicKeyRetrieval=true
     username: root
-    password: 1234
+    password: YOUR_DB_PASSWORD
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
@@ -19,3 +19,14 @@ logging:
   level:
     com.lectureq: DEBUG
     org.hibernate.SQL: DEBUG
+
+jwt:
+  secret: YOUR_JWT_SECRET_BASE64_ENCODED_MIN_32_BYTES
+
+kakao:
+  client-id: YOUR_KAKAO_REST_API_KEY
+  client-secret: YOUR_KAKAO_CLIENT_SECRET
+  redirect-uri: http://localhost:5173/oauth/callback
+
+cookie:
+  secure: false

--- a/server/src/main/resources/application-prod.yml
+++ b/server/src/main/resources/application-prod.yml
@@ -12,3 +12,6 @@ spring:
 logging:
   level:
     com.lectureq: INFO
+
+cookie:
+  secure: true

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -3,3 +3,13 @@ spring:
     name: lectureq
   profiles:
     active: local
+
+jwt:
+  secret: ${JWT_SECRET}
+  access-expiration: 1800000
+  refresh-expiration: 1209600000
+
+kakao:
+  client-id: ${KAKAO_CLIENT_ID}
+  client-secret: ${KAKAO_CLIENT_SECRET}
+  redirect-uri: ${KAKAO_REDIRECT_URI}

--- a/server/src/main/resources/schema.sql
+++ b/server/src/main/resources/schema.sql
@@ -43,7 +43,7 @@ CREATE TABLE question (
 CREATE TABLE refresh_token (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     user_id BIGINT NOT NULL,
-    token VARCHAR(255) NOT NULL UNIQUE,
+    token TEXT NOT NULL,
     expired_at DATETIME NOT NULL,
     created_at DATETIME NOT NULL,
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE

--- a/server/src/main/resources/schema.sql
+++ b/server/src/main/resources/schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE users (
     updated_at DATETIME NOT NULL
 );
 
-CREATE TABLE recording (
+CREATE TABLE recordings (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     user_id BIGINT NOT NULL,
     title VARCHAR(100) NOT NULL,
@@ -17,7 +17,7 @@ CREATE TABLE recording (
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 );
 
-CREATE TABLE analysis (
+CREATE TABLE analyses (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     recording_id BIGINT NOT NULL UNIQUE,
     status VARCHAR(20) NOT NULL,
@@ -28,23 +28,24 @@ CREATE TABLE analysis (
     created_at DATETIME NOT NULL,
     updated_at DATETIME NOT NULL,
     completed_at DATETIME,
-    FOREIGN KEY (recording_id) REFERENCES recording(id) ON DELETE CASCADE
+    FOREIGN KEY (recording_id) REFERENCES recordings(id) ON DELETE CASCADE
 );
 
-CREATE TABLE question (
+CREATE TABLE questions (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     analysis_id BIGINT NOT NULL,
     content TEXT NOT NULL,
     order_num INT NOT NULL,
     created_at DATETIME NOT NULL,
-    FOREIGN KEY (analysis_id) REFERENCES analysis(id) ON DELETE CASCADE
+    FOREIGN KEY (analysis_id) REFERENCES analyses(id) ON DELETE CASCADE
 );
 
-CREATE TABLE refresh_token (
+CREATE TABLE refresh_tokens (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     user_id BIGINT NOT NULL,
-    token TEXT NOT NULL,
+    token VARCHAR(500) NOT NULL,
     expired_at DATETIME NOT NULL,
     created_at DATETIME NOT NULL,
+    INDEX idx_refresh_tokens_token (token),
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 );

--- a/server/src/test/java/com/lectureq/server/auth/controller/AuthControllerTest.java
+++ b/server/src/test/java/com/lectureq/server/auth/controller/AuthControllerTest.java
@@ -1,0 +1,98 @@
+package com.lectureq.server.auth.controller;
+
+import com.lectureq.server.auth.dto.LoginResponse;
+import com.lectureq.server.auth.service.AuthService;
+import com.lectureq.server.global.config.SecurityConfig;
+import com.lectureq.server.global.error.GlobalExceptionHandler;
+import com.lectureq.server.user.entity.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.lectureq.server.global.error.BusinessException;
+import com.lectureq.server.global.error.ErrorCode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(AuthController.class)
+@Import({SecurityConfig.class, GlobalExceptionHandler.class})
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AuthService authService;
+
+    @Test
+    void 로그인_성공() throws Exception {
+        // given
+        User user = User.builder()
+                .kakaoId("12345")
+                .nickname("홍길동")
+                .profileImage("https://profile.jpg")
+                .build();
+        LoginResponse loginResponse = new LoginResponse(user);
+        AuthService.LoginResult result = new AuthService.LoginResult(
+                "access-token", "refresh-token", loginResponse);
+        given(authService.login(anyString())).willReturn(result);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"code\": \"test-code\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("로그인 성공"))
+                .andExpect(jsonPath("$.data.user.nickname").value("홍길동"))
+                .andExpect(header().exists("Set-Cookie"))
+                .andDo(result1 -> {
+                    var cookies = result1.getResponse().getHeaders("Set-Cookie");
+                    String accessCookie = cookies.stream()
+                            .filter(c -> c.startsWith("accessToken="))
+                            .findFirst().orElseThrow();
+                    assertThat(accessCookie).contains("HttpOnly");
+                    assertThat(accessCookie).contains("SameSite=Lax");
+                    assertThat(accessCookie).contains("Path=/");
+
+                    String refreshCookie = cookies.stream()
+                            .filter(c -> c.startsWith("refreshToken="))
+                            .findFirst().orElseThrow();
+                    assertThat(refreshCookie).contains("HttpOnly");
+                    assertThat(refreshCookie).contains("SameSite=Lax");
+                    assertThat(refreshCookie).contains("Path=/api/v1/auth");
+                });
+    }
+
+    @Test
+    void 인가코드_누락시_400() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"code\": \"\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400));
+    }
+
+    @Test
+    void 유효하지_않은_카카오_토큰_401() throws Exception {
+        // given
+        given(authService.login(anyString()))
+                .willThrow(new BusinessException(ErrorCode.UNAUTHORIZED, "카카오 인가 코드가 유효하지 않습니다."));
+
+        // when & then
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"code\": \"invalid-code\"}"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.message").value("카카오 인가 코드가 유효하지 않습니다."));
+    }
+}

--- a/server/src/test/java/com/lectureq/server/auth/service/AuthServiceTest.java
+++ b/server/src/test/java/com/lectureq/server/auth/service/AuthServiceTest.java
@@ -1,0 +1,109 @@
+package com.lectureq.server.auth.service;
+
+import com.lectureq.server.auth.entity.RefreshToken;
+import com.lectureq.server.auth.repository.RefreshTokenRepository;
+import com.lectureq.server.global.infra.kakao.KakaoClient;
+import com.lectureq.server.global.infra.kakao.KakaoTokenResponse;
+import com.lectureq.server.global.infra.kakao.KakaoUserResponse;
+import com.lectureq.server.global.jwt.JwtProvider;
+import com.lectureq.server.user.entity.User;
+import com.lectureq.server.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Mock
+    private KakaoClient kakaoClient;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @Mock
+    private KakaoTokenResponse kakaoTokenResponse;
+
+    @Mock
+    private KakaoUserResponse kakaoUserResponse;
+
+    @Test
+    void 신규_사용자_로그인_성공() {
+        // given
+        given(kakaoClient.getToken("test-code")).willReturn(kakaoTokenResponse);
+        given(kakaoTokenResponse.getAccessToken()).willReturn("kakao-access-token");
+        given(kakaoClient.getUserInfo("kakao-access-token")).willReturn(kakaoUserResponse);
+        given(kakaoUserResponse.getId()).willReturn(12345L);
+        given(kakaoUserResponse.getNickname()).willReturn("홍길동");
+        given(kakaoUserResponse.getProfileImageUrl()).willReturn("https://profile.jpg");
+        given(userRepository.findByKakaoId("12345")).willReturn(Optional.empty());
+
+        User savedUser = User.builder()
+                .kakaoId("12345")
+                .nickname("홍길동")
+                .profileImage("https://profile.jpg")
+                .build();
+        given(userRepository.save(any(User.class))).willReturn(savedUser);
+        given(jwtProvider.createAccessToken(any())).willReturn("access-token");
+        given(jwtProvider.createRefreshToken(any())).willReturn("refresh-token");
+        given(refreshTokenRepository.save(any(RefreshToken.class))).willReturn(null);
+
+        // when
+        AuthService.LoginResult result = authService.login("test-code");
+
+        // then
+        assertThat(result.accessToken()).isEqualTo("access-token");
+        assertThat(result.refreshToken()).isEqualTo("refresh-token");
+        assertThat(result.loginResponse().getUser().getNickname()).isEqualTo("홍길동");
+        verify(userRepository).save(any(User.class));
+    }
+
+    @Test
+    void 기존_사용자_로그인_프로필_업데이트() {
+        // given
+        given(kakaoClient.getToken("test-code")).willReturn(kakaoTokenResponse);
+        given(kakaoTokenResponse.getAccessToken()).willReturn("kakao-access-token");
+        given(kakaoClient.getUserInfo("kakao-access-token")).willReturn(kakaoUserResponse);
+        given(kakaoUserResponse.getId()).willReturn(12345L);
+        given(kakaoUserResponse.getNickname()).willReturn("새닉네임");
+        given(kakaoUserResponse.getProfileImageUrl()).willReturn("https://new-profile.jpg");
+
+        User existingUser = User.builder()
+                .kakaoId("12345")
+                .nickname("기존닉네임")
+                .profileImage("https://old-profile.jpg")
+                .build();
+        given(userRepository.findByKakaoId("12345")).willReturn(Optional.of(existingUser));
+        given(jwtProvider.createAccessToken(any())).willReturn("access-token");
+        given(jwtProvider.createRefreshToken(any())).willReturn("refresh-token");
+        given(refreshTokenRepository.save(any(RefreshToken.class))).willReturn(null);
+
+        // when
+        AuthService.LoginResult result = authService.login("test-code");
+
+        // then
+        assertThat(existingUser.getNickname()).isEqualTo("새닉네임");
+        assertThat(existingUser.getProfileImage()).isEqualTo("https://new-profile.jpg");
+        verify(userRepository, never()).save(any(User.class));
+        verify(refreshTokenRepository).deleteByUser(existingUser);
+    }
+}

--- a/server/src/test/java/com/lectureq/server/global/error/GlobalExceptionHandlerTest.java
+++ b/server/src/test/java/com/lectureq/server/global/error/GlobalExceptionHandlerTest.java
@@ -1,5 +1,6 @@
 package com.lectureq.server.global.error;
 
+import com.lectureq.server.auth.service.AuthService;
 import com.lectureq.server.global.response.ApiResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -9,6 +10,7 @@ import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -28,6 +30,9 @@ class GlobalExceptionHandlerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @MockitoBean
+    private AuthService authService;
 
     @Test
     void businessException_default_message() throws Exception {

--- a/server/src/test/resources/application-test.yml
+++ b/server/src/test/resources/application-test.yml
@@ -11,3 +11,16 @@ spring:
     properties:
       hibernate:
         format_sql: true
+
+jwt:
+  secret: dGVzdC1zZWNyZXQta2V5LW11c3QtYmUtYXQtbGVhc3QtMzItYnl0ZXMtbG9uZw==
+  access-expiration: 1800000
+  refresh-expiration: 1209600000
+
+cookie:
+  secure: false
+
+kakao:
+  client-id: test-client-id
+  client-secret: test-client-secret
+  redirect-uri: http://localhost:3000/oauth/callback


### PR DESCRIPTION
## 변경 사항
- 카카오 API 연동 (사용자 정보 조회)
- JWT 발급 및 HttpOnly Cookie 설정
- 신규 사용자 자동 회원가입
- Refresh Token DB 저장

## 테스트
- 카카오 토큰으로 로그인 성공
- 첫 로그인 시 자동 회원가입 확인
- Set-Cookie 헤더에 HttpOnly, Secure, SameSite 설정 확인
- 유효하지 않은 카카오 토큰 → 401

closes #61