### PR TITLE
[#62] 토큰 갱신/로그아웃 API + JWT 인증 필터 구현

### DIFF
--- a/server/src/main/java/com/lectureq/server/ServerApplication.java
+++ b/server/src/main/java/com/lectureq/server/ServerApplication.java
@@ -2,8 +2,10 @@ package com.lectureq.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class ServerApplication {
 
 	public static void main(String[] args) {

--- a/server/src/main/java/com/lectureq/server/auth/AuthCookieFactory.java
+++ b/server/src/main/java/com/lectureq/server/auth/AuthCookieFactory.java
@@ -1,0 +1,48 @@
+package com.lectureq.server.auth;
+
+import com.lectureq.server.auth.config.CookieProperties;
+import com.lectureq.server.global.jwt.JwtProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AuthCookieFactory {
+
+    public static final String ACCESS_TOKEN = "accessToken";
+    public static final String REFRESH_TOKEN = "refreshToken";
+
+    private static final String ACCESS_TOKEN_PATH = "/";
+    private static final String REFRESH_TOKEN_PATH = "/api/v1/auth";
+    private static final String SAME_SITE = "Lax";
+
+    private final CookieProperties cookieProperties;
+    private final JwtProperties jwtProperties;
+
+    public ResponseCookie accessToken(String value) {
+        return build(ACCESS_TOKEN, value, ACCESS_TOKEN_PATH, jwtProperties.accessExpiration() / 1000);
+    }
+
+    public ResponseCookie refreshToken(String value) {
+        return build(REFRESH_TOKEN, value, REFRESH_TOKEN_PATH, jwtProperties.refreshExpiration() / 1000);
+    }
+
+    public ResponseCookie expiredAccessToken() {
+        return build(ACCESS_TOKEN, "", ACCESS_TOKEN_PATH, 0);
+    }
+
+    public ResponseCookie expiredRefreshToken() {
+        return build(REFRESH_TOKEN, "", REFRESH_TOKEN_PATH, 0);
+    }
+
+    private ResponseCookie build(String name, String value, String path, long maxAgeSeconds) {
+        return ResponseCookie.from(name, value)
+                .httpOnly(true)
+                .secure(cookieProperties.secure())
+                .sameSite(SAME_SITE)
+                .path(path)
+                .maxAge(maxAgeSeconds)
+                .build();
+    }
+}

--- a/server/src/main/java/com/lectureq/server/auth/config/CookieProperties.java
+++ b/server/src/main/java/com/lectureq/server/auth/config/CookieProperties.java
@@ -1,0 +1,8 @@
+package com.lectureq.server.auth.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "cookie")
+public record CookieProperties(
+        boolean secure
+) {}

--- a/server/src/main/java/com/lectureq/server/auth/controller/AuthController.java
+++ b/server/src/main/java/com/lectureq/server/auth/controller/AuthController.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -41,8 +42,8 @@ public class AuthController {
     public ResponseEntity<ApiResponse<LoginResponse>> login(@RequestBody @Valid LoginRequest request) {
         AuthService.LoginResult result = authService.login(request.getCode());
 
-        ResponseCookie accessTokenCookie = buildAccessTokenCookie(result.accessToken());
-        ResponseCookie refreshTokenCookie = buildRefreshTokenCookie(result.refreshToken());
+        ResponseCookie accessTokenCookie = buildAccessTokenCookie(result.accessToken(), accessTokenExpirationMs / 1000);
+        ResponseCookie refreshTokenCookie = buildRefreshTokenCookie(result.refreshToken(), refreshTokenExpirationMs / 1000);
 
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
@@ -50,23 +51,51 @@ public class AuthController {
                 .body(ApiResponse.success("로그인 성공", result.loginResponse()));
     }
 
-    private ResponseCookie buildAccessTokenCookie(String value) {
+    @PostMapping("/refresh")
+    public ResponseEntity<ApiResponse<Void>> refresh(
+            @CookieValue(name = REFRESH_TOKEN_COOKIE_NAME, required = false) String refreshToken) {
+        AuthService.RefreshResult result = authService.refresh(refreshToken);
+
+        ResponseCookie accessTokenCookie = buildAccessTokenCookie(result.accessToken(), accessTokenExpirationMs / 1000);
+        ResponseCookie refreshTokenCookie = buildRefreshTokenCookie(result.refreshToken(), refreshTokenExpirationMs / 1000);
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
+                .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
+                .body(ApiResponse.successMessage("토큰 재발급 성공"));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(
+            @CookieValue(name = REFRESH_TOKEN_COOKIE_NAME, required = false) String refreshToken) {
+        authService.logout(refreshToken);
+
+        ResponseCookie expiredAccessToken = buildAccessTokenCookie("", 0);
+        ResponseCookie expiredRefreshToken = buildRefreshTokenCookie("", 0);
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, expiredAccessToken.toString())
+                .header(HttpHeaders.SET_COOKIE, expiredRefreshToken.toString())
+                .body(ApiResponse.successMessage("로그아웃 성공"));
+    }
+
+    private ResponseCookie buildAccessTokenCookie(String value, long maxAgeSeconds) {
         return ResponseCookie.from(ACCESS_TOKEN_COOKIE_NAME, value)
                 .httpOnly(true)
                 .secure(cookieSecure)
                 .sameSite(COOKIE_SAME_SITE)
                 .path(ACCESS_TOKEN_COOKIE_PATH)
-                .maxAge(accessTokenExpirationMs / 1000)
+                .maxAge(maxAgeSeconds)
                 .build();
     }
 
-    private ResponseCookie buildRefreshTokenCookie(String value) {
+    private ResponseCookie buildRefreshTokenCookie(String value, long maxAgeSeconds) {
         return ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, value)
                 .httpOnly(true)
                 .secure(cookieSecure)
                 .sameSite(COOKIE_SAME_SITE)
                 .path(REFRESH_TOKEN_COOKIE_PATH)
-                .maxAge(refreshTokenExpirationMs / 1000)
+                .maxAge(maxAgeSeconds)
                 .build();
     }
 }

--- a/server/src/main/java/com/lectureq/server/auth/controller/AuthController.java
+++ b/server/src/main/java/com/lectureq/server/auth/controller/AuthController.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -66,9 +67,9 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<ApiResponse<Void>> logout(
-            @CookieValue(name = REFRESH_TOKEN_COOKIE_NAME, required = false) String refreshToken) {
-        authService.logout(refreshToken);
+    public ResponseEntity<ApiResponse<Void>> logout() {
+        Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        authService.logout(userId);
 
         ResponseCookie expiredAccessToken = buildAccessTokenCookie("", 0);
         ResponseCookie expiredRefreshToken = buildRefreshTokenCookie("", 0);

--- a/server/src/main/java/com/lectureq/server/auth/controller/AuthController.java
+++ b/server/src/main/java/com/lectureq/server/auth/controller/AuthController.java
@@ -1,14 +1,13 @@
 package com.lectureq.server.auth.controller;
 
+import com.lectureq.server.auth.AuthCookieFactory;
 import com.lectureq.server.auth.dto.LoginRequest;
 import com.lectureq.server.auth.dto.LoginResponse;
 import com.lectureq.server.auth.service.AuthService;
 import com.lectureq.server.global.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.CookieValue;
@@ -22,47 +21,27 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AuthController {
 
-    private static final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
-    private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
-    private static final String ACCESS_TOKEN_COOKIE_PATH = "/";
-    private static final String REFRESH_TOKEN_COOKIE_PATH = "/api/v1/auth";
-    private static final String COOKIE_SAME_SITE = "Lax";
-
     private final AuthService authService;
-
-    @Value("${cookie.secure}")
-    private boolean cookieSecure;
-
-    @Value("${jwt.access-expiration}")
-    private long accessTokenExpirationMs;
-
-    @Value("${jwt.refresh-expiration}")
-    private long refreshTokenExpirationMs;
+    private final AuthCookieFactory cookieFactory;
 
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<LoginResponse>> login(@RequestBody @Valid LoginRequest request) {
         AuthService.LoginResult result = authService.login(request.getCode());
 
-        ResponseCookie accessTokenCookie = buildAccessTokenCookie(result.accessToken(), accessTokenExpirationMs / 1000);
-        ResponseCookie refreshTokenCookie = buildRefreshTokenCookie(result.refreshToken(), refreshTokenExpirationMs / 1000);
-
         return ResponseEntity.ok()
-                .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
-                .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
+                .header(HttpHeaders.SET_COOKIE, cookieFactory.accessToken(result.accessToken()).toString())
+                .header(HttpHeaders.SET_COOKIE, cookieFactory.refreshToken(result.refreshToken()).toString())
                 .body(ApiResponse.success("로그인 성공", result.loginResponse()));
     }
 
     @PostMapping("/refresh")
     public ResponseEntity<ApiResponse<Void>> refresh(
-            @CookieValue(name = REFRESH_TOKEN_COOKIE_NAME, required = false) String refreshToken) {
+            @CookieValue(name = AuthCookieFactory.REFRESH_TOKEN, required = false) String refreshToken) {
         AuthService.RefreshResult result = authService.refresh(refreshToken);
 
-        ResponseCookie accessTokenCookie = buildAccessTokenCookie(result.accessToken(), accessTokenExpirationMs / 1000);
-        ResponseCookie refreshTokenCookie = buildRefreshTokenCookie(result.refreshToken(), refreshTokenExpirationMs / 1000);
-
         return ResponseEntity.ok()
-                .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
-                .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
+                .header(HttpHeaders.SET_COOKIE, cookieFactory.accessToken(result.accessToken()).toString())
+                .header(HttpHeaders.SET_COOKIE, cookieFactory.refreshToken(result.refreshToken()).toString())
                 .body(ApiResponse.successMessage("토큰 재발급 성공"));
     }
 
@@ -71,32 +50,9 @@ public class AuthController {
         Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         authService.logout(userId);
 
-        ResponseCookie expiredAccessToken = buildAccessTokenCookie("", 0);
-        ResponseCookie expiredRefreshToken = buildRefreshTokenCookie("", 0);
-
         return ResponseEntity.ok()
-                .header(HttpHeaders.SET_COOKIE, expiredAccessToken.toString())
-                .header(HttpHeaders.SET_COOKIE, expiredRefreshToken.toString())
+                .header(HttpHeaders.SET_COOKIE, cookieFactory.expiredAccessToken().toString())
+                .header(HttpHeaders.SET_COOKIE, cookieFactory.expiredRefreshToken().toString())
                 .body(ApiResponse.successMessage("로그아웃 성공"));
-    }
-
-    private ResponseCookie buildAccessTokenCookie(String value, long maxAgeSeconds) {
-        return ResponseCookie.from(ACCESS_TOKEN_COOKIE_NAME, value)
-                .httpOnly(true)
-                .secure(cookieSecure)
-                .sameSite(COOKIE_SAME_SITE)
-                .path(ACCESS_TOKEN_COOKIE_PATH)
-                .maxAge(maxAgeSeconds)
-                .build();
-    }
-
-    private ResponseCookie buildRefreshTokenCookie(String value, long maxAgeSeconds) {
-        return ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, value)
-                .httpOnly(true)
-                .secure(cookieSecure)
-                .sameSite(COOKIE_SAME_SITE)
-                .path(REFRESH_TOKEN_COOKIE_PATH)
-                .maxAge(maxAgeSeconds)
-                .build();
     }
 }

--- a/server/src/main/java/com/lectureq/server/auth/repository/RefreshTokenRepository.java
+++ b/server/src/main/java/com/lectureq/server/auth/repository/RefreshTokenRepository.java
@@ -4,6 +4,9 @@ import com.lectureq.server.auth.entity.RefreshToken;
 import com.lectureq.server.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
     void deleteByUser(User user);
+    Optional<RefreshToken> findByToken(String token);
 }

--- a/server/src/main/java/com/lectureq/server/auth/service/AuthService.java
+++ b/server/src/main/java/com/lectureq/server/auth/service/AuthService.java
@@ -8,11 +8,11 @@ import com.lectureq.server.global.error.ErrorCode;
 import com.lectureq.server.global.infra.kakao.KakaoClient;
 import com.lectureq.server.global.infra.kakao.KakaoTokenResponse;
 import com.lectureq.server.global.infra.kakao.KakaoUserResponse;
+import com.lectureq.server.global.jwt.JwtProperties;
 import com.lectureq.server.global.jwt.JwtProvider;
 import com.lectureq.server.user.entity.User;
 import com.lectureq.server.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,9 +27,7 @@ public class AuthService {
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtProvider jwtProvider;
-
-    @Value("${jwt.refresh-expiration}")
-    private long refreshTokenExpirationMs;
+    private final JwtProperties jwtProperties;
 
     @Transactional
     public LoginResult login(String code) {
@@ -66,7 +64,7 @@ public class AuthService {
         refreshTokenRepository.save(RefreshToken.builder()
                 .user(user)
                 .token(refreshToken)
-                .expiredAt(LocalDateTime.now().plusNanos(refreshTokenExpirationMs * 1_000_000))
+                .expiredAt(LocalDateTime.now().plusNanos(jwtProperties.refreshExpiration() * 1_000_000))
                 .build());
 
         // 8. 응답
@@ -104,7 +102,7 @@ public class AuthService {
         refreshTokenRepository.save(RefreshToken.builder()
                 .user(storedToken.getUser())
                 .token(newRefreshToken)
-                .expiredAt(LocalDateTime.now().plusNanos(refreshTokenExpirationMs * 1_000_000))
+                .expiredAt(LocalDateTime.now().plusNanos(jwtProperties.refreshExpiration() * 1_000_000))
                 .build());
 
         return new RefreshResult(newAccessToken, newRefreshToken);

--- a/server/src/main/java/com/lectureq/server/auth/service/AuthService.java
+++ b/server/src/main/java/com/lectureq/server/auth/service/AuthService.java
@@ -3,6 +3,8 @@ package com.lectureq.server.auth.service;
 import com.lectureq.server.auth.dto.LoginResponse;
 import com.lectureq.server.auth.entity.RefreshToken;
 import com.lectureq.server.auth.repository.RefreshTokenRepository;
+import com.lectureq.server.global.error.BusinessException;
+import com.lectureq.server.global.error.ErrorCode;
 import com.lectureq.server.global.infra.kakao.KakaoClient;
 import com.lectureq.server.global.infra.kakao.KakaoTokenResponse;
 import com.lectureq.server.global.infra.kakao.KakaoUserResponse;
@@ -72,4 +74,43 @@ public class AuthService {
     }
 
     public record LoginResult(String accessToken, String refreshToken, LoginResponse loginResponse) {}
+
+    @Transactional
+    public RefreshResult refresh(String refreshToken) {
+        // 1. 토큰 유효성 검증
+        if (refreshToken == null || !jwtProvider.validateToken(refreshToken)) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED, "Refresh Token이 만료되었습니다. 다시 로그인해주세요.");
+        }
+
+        // 2. DB에서 존재 여부 확인
+        RefreshToken storedToken = refreshTokenRepository.findByToken(refreshToken)
+                .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED, "Refresh Token이 만료되었습니다. 다시 로그인해주세요."));
+
+        // 3. 기존 Refresh Token 삭제 (Token Rotation)
+        refreshTokenRepository.delete(storedToken);
+
+        // 4. 새 토큰 쌍 생성
+        Long userId = storedToken.getUser().getId();
+        String newAccessToken = jwtProvider.createAccessToken(userId);
+        String newRefreshToken = jwtProvider.createRefreshToken(userId);
+
+        // 5. 새 Refresh Token 저장
+        refreshTokenRepository.save(RefreshToken.builder()
+                .user(storedToken.getUser())
+                .token(newRefreshToken)
+                .expiredAt(LocalDateTime.now().plusDays(14))
+                .build());
+
+        return new RefreshResult(newAccessToken, newRefreshToken);
+    }
+
+    public record RefreshResult(String accessToken, String refreshToken) {}
+
+    @Transactional
+    public void logout(String refreshToken) {
+        if (refreshToken != null) {
+            refreshTokenRepository.findByToken(refreshToken)
+                    .ifPresent(refreshTokenRepository::delete);
+        }
+    }
 }

--- a/server/src/main/java/com/lectureq/server/auth/service/AuthService.java
+++ b/server/src/main/java/com/lectureq/server/auth/service/AuthService.java
@@ -77,7 +77,7 @@ public class AuthService {
 
     @Transactional
     public RefreshResult refresh(String refreshToken) {
-        // 1. 토큰 유효성 검증
+        // 1. 토큰 유효성 검증 (서명/형식)
         if (refreshToken == null || !jwtProvider.validateToken(refreshToken)) {
             throw new BusinessException(ErrorCode.UNAUTHORIZED, "Refresh Token이 만료되었습니다. 다시 로그인해주세요.");
         }
@@ -86,19 +86,25 @@ public class AuthService {
         RefreshToken storedToken = refreshTokenRepository.findByToken(refreshToken)
                 .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED, "Refresh Token이 만료되었습니다. 다시 로그인해주세요."));
 
-        // 3. 기존 Refresh Token 삭제 (Token Rotation)
+        // 3. DB에 저장된 만료 시각 검증 (서버 측 강제 무효화 정책 지원)
+        if (storedToken.getExpiredAt().isBefore(LocalDateTime.now())) {
+            refreshTokenRepository.delete(storedToken);
+            throw new BusinessException(ErrorCode.UNAUTHORIZED, "Refresh Token이 만료되었습니다. 다시 로그인해주세요.");
+        }
+
+        // 4. 기존 Refresh Token 삭제 (Token Rotation)
         refreshTokenRepository.delete(storedToken);
 
-        // 4. 새 토큰 쌍 생성
+        // 5. 새 토큰 쌍 생성
         Long userId = storedToken.getUser().getId();
         String newAccessToken = jwtProvider.createAccessToken(userId);
         String newRefreshToken = jwtProvider.createRefreshToken(userId);
 
-        // 5. 새 Refresh Token 저장
+        // 6. 새 Refresh Token 저장
         refreshTokenRepository.save(RefreshToken.builder()
                 .user(storedToken.getUser())
                 .token(newRefreshToken)
-                .expiredAt(LocalDateTime.now().plusDays(14))
+                .expiredAt(LocalDateTime.now().plusNanos(refreshTokenExpirationMs * 1_000_000))
                 .build());
 
         return new RefreshResult(newAccessToken, newRefreshToken);
@@ -107,10 +113,8 @@ public class AuthService {
     public record RefreshResult(String accessToken, String refreshToken) {}
 
     @Transactional
-    public void logout(String refreshToken) {
-        if (refreshToken != null) {
-            refreshTokenRepository.findByToken(refreshToken)
-                    .ifPresent(refreshTokenRepository::delete);
-        }
+    public void logout(Long userId) {
+        userRepository.findById(userId)
+                .ifPresent(refreshTokenRepository::deleteByUser);
     }
 }

--- a/server/src/main/java/com/lectureq/server/global/config/SecurityConfig.java
+++ b/server/src/main/java/com/lectureq/server/global/config/SecurityConfig.java
@@ -1,15 +1,23 @@
 package com.lectureq.server.global.config;
 
+import com.lectureq.server.global.jwt.JwtAuthenticationEntryPoint;
+import com.lectureq.server.global.jwt.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -19,7 +27,10 @@ public class SecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/v1/auth/login", "/api/v1/auth/refresh", "/api/v1/auth/logout").permitAll()
-                        .anyRequest().authenticated());
+                        .anyRequest().authenticated())
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint))
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/server/src/main/java/com/lectureq/server/global/config/SecurityConfig.java
+++ b/server/src/main/java/com/lectureq/server/global/config/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/v1/auth/login", "/api/v1/auth/refresh", "/api/v1/auth/logout").permitAll()
+                        .requestMatchers("/api/v1/auth/login", "/api/v1/auth/refresh").permitAll()
                         .anyRequest().authenticated())
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint))

--- a/server/src/main/java/com/lectureq/server/global/infra/kakao/KakaoClient.java
+++ b/server/src/main/java/com/lectureq/server/global/infra/kakao/KakaoClient.java
@@ -2,7 +2,8 @@ package com.lectureq.server.global.infra.kakao;
 
 import com.lectureq.server.global.error.BusinessException;
 import com.lectureq.server.global.error.ErrorCode;
-import org.springframework.beans.factory.annotation.Value;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
@@ -15,23 +16,18 @@ import org.springframework.web.client.RestClientResponseException;
 import java.time.Duration;
 
 @Component
+@RequiredArgsConstructor
 public class KakaoClient {
 
-    private final RestClient restClient;
-    private final String clientId;
-    private final String clientSecret;
-    private final String redirectUri;
+    private final KakaoProperties properties;
 
-    public KakaoClient(
-            @Value("${kakao.client-id}") String clientId,
-            @Value("${kakao.client-secret}") String clientSecret,
-            @Value("${kakao.redirect-uri}") String redirectUri) {
+    private RestClient restClient;
+
+    @PostConstruct
+    void init() {
         this.restClient = RestClient.builder()
                 .requestFactory(clientHttpRequestFactory())
                 .build();
-        this.clientId = clientId;
-        this.clientSecret = clientSecret;
-        this.redirectUri = redirectUri;
     }
 
     private ClientHttpRequestFactory clientHttpRequestFactory() {
@@ -44,10 +40,10 @@ public class KakaoClient {
     public KakaoTokenResponse getToken(String code) {
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("grant_type", "authorization_code");
-        params.add("client_id", clientId);
-        params.add("redirect_uri", redirectUri);
+        params.add("client_id", properties.clientId());
+        params.add("redirect_uri", properties.redirectUri());
         params.add("code", code);
-        params.add("client_secret", clientSecret);
+        params.add("client_secret", properties.clientSecret());
 
         try {
             return restClient.post()

--- a/server/src/main/java/com/lectureq/server/global/infra/kakao/KakaoProperties.java
+++ b/server/src/main/java/com/lectureq/server/global/infra/kakao/KakaoProperties.java
@@ -1,0 +1,10 @@
+package com.lectureq.server.global.infra.kakao;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "kakao")
+public record KakaoProperties(
+        String clientId,
+        String clientSecret,
+        String redirectUri
+) {}

--- a/server/src/main/java/com/lectureq/server/global/jwt/JwtAuthenticationEntryPoint.java
+++ b/server/src/main/java/com/lectureq/server/global/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,25 @@
+package com.lectureq.server.global.jwt;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        String body = "{\"status\":401,\"message\":\"인증이 필요합니다.\"}";
+        response.getWriter().write(body);
+    }
+}

--- a/server/src/main/java/com/lectureq/server/global/jwt/JwtAuthenticationFilter.java
+++ b/server/src/main/java/com/lectureq/server/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,49 @@
+package com.lectureq.server.global.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String token = extractToken(request);
+
+        if (token != null && jwtProvider.validateToken(token)) {
+            Long userId = jwtProvider.getUserId(token);
+            Authentication authentication = new UsernamePasswordAuthenticationToken(
+                    userId, null, Collections.emptyList());
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String extractToken(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) return null;
+        for (Cookie cookie : cookies) {
+            if ("accessToken".equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+}

--- a/server/src/main/java/com/lectureq/server/global/jwt/JwtProperties.java
+++ b/server/src/main/java/com/lectureq/server/global/jwt/JwtProperties.java
@@ -1,0 +1,10 @@
+package com.lectureq.server.global.jwt;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jwt")
+public record JwtProperties(
+        String secret,
+        long accessExpiration,
+        long refreshExpiration
+) {}

--- a/server/src/main/java/com/lectureq/server/global/jwt/JwtProvider.java
+++ b/server/src/main/java/com/lectureq/server/global/jwt/JwtProvider.java
@@ -1,5 +1,6 @@
 package com.lectureq.server.global.jwt;
 
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
@@ -31,6 +32,28 @@ public class JwtProvider {
 
     public String createRefreshToken(Long userId) {
         return createToken(userId, refreshExpiration);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    public Long getUserId(String token) {
+        String subject = Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getSubject();
+        return Long.parseLong(subject);
     }
 
     private String createToken(Long userId, long expiration) {

--- a/server/src/main/java/com/lectureq/server/global/jwt/JwtProvider.java
+++ b/server/src/main/java/com/lectureq/server/global/jwt/JwtProvider.java
@@ -3,7 +3,8 @@ package com.lectureq.server.global.jwt;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
-import org.springframework.beans.factory.annotation.Value;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
@@ -11,27 +12,24 @@ import java.util.Base64;
 import java.util.Date;
 
 @Component
+@RequiredArgsConstructor
 public class JwtProvider {
 
-    private final SecretKey secretKey;
-    private final long accessExpiration;
-    private final long refreshExpiration;
+    private final JwtProperties properties;
 
-    public JwtProvider(
-            @Value("${jwt.secret}") String secret,
-            @Value("${jwt.access-expiration}") long accessExpiration,
-            @Value("${jwt.refresh-expiration}") long refreshExpiration) {
-        this.secretKey = Keys.hmacShaKeyFor(Base64.getDecoder().decode(secret));
-        this.accessExpiration = accessExpiration;
-        this.refreshExpiration = refreshExpiration;
+    private SecretKey secretKey;
+
+    @PostConstruct
+    void init() {
+        this.secretKey = Keys.hmacShaKeyFor(Base64.getDecoder().decode(properties.secret()));
     }
 
     public String createAccessToken(Long userId) {
-        return createToken(userId, accessExpiration);
+        return createToken(userId, properties.accessExpiration());
     }
 
     public String createRefreshToken(Long userId) {
-        return createToken(userId, refreshExpiration);
+        return createToken(userId, properties.refreshExpiration());
     }
 
     public boolean validateToken(String token) {

--- a/server/src/main/java/com/lectureq/server/global/response/ApiResponse.java
+++ b/server/src/main/java/com/lectureq/server/global/response/ApiResponse.java
@@ -1,21 +1,18 @@
 package com.lectureq.server.global.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ApiResponse<T> {
 
     private final int status;
     private final String message;
     private final T data;
-
-    private ApiResponse(int status, String message, T data) {
-        this.status = status;
-        this.message = message;
-        this.data = data;
-    }
 
     public static <T> ApiResponse<T> success(T data) {
         return new ApiResponse<>(200, "성공", data);

--- a/server/src/test/java/com/lectureq/server/auth/controller/AuthControllerTest.java
+++ b/server/src/test/java/com/lectureq/server/auth/controller/AuthControllerTest.java
@@ -4,6 +4,9 @@ import com.lectureq.server.auth.dto.LoginResponse;
 import com.lectureq.server.auth.service.AuthService;
 import com.lectureq.server.global.config.SecurityConfig;
 import com.lectureq.server.global.error.GlobalExceptionHandler;
+import com.lectureq.server.global.jwt.JwtAuthenticationEntryPoint;
+import com.lectureq.server.global.jwt.JwtAuthenticationFilter;
+import com.lectureq.server.global.jwt.JwtProvider;
 import com.lectureq.server.user.entity.User;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,13 +20,14 @@ import com.lectureq.server.global.error.BusinessException;
 import com.lectureq.server.global.error.ErrorCode;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(AuthController.class)
-@Import({SecurityConfig.class, GlobalExceptionHandler.class})
+@Import({SecurityConfig.class, GlobalExceptionHandler.class, JwtAuthenticationFilter.class, JwtAuthenticationEntryPoint.class})
 class AuthControllerTest {
 
     @Autowired
@@ -31,6 +35,9 @@ class AuthControllerTest {
 
     @MockitoBean
     private AuthService authService;
+
+    @MockitoBean
+    private JwtProvider jwtProvider;
 
     @Test
     void 로그인_성공() throws Exception {
@@ -94,5 +101,58 @@ class AuthControllerTest {
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.status").value(401))
                 .andExpect(jsonPath("$.message").value("카카오 인가 코드가 유효하지 않습니다."));
+    }
+
+    @Test
+    void 토큰_갱신_성공() throws Exception {
+        // given
+        AuthService.RefreshResult result = new AuthService.RefreshResult("new-access", "new-refresh");
+        given(authService.refresh(anyString())).willReturn(result);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/auth/refresh")
+                        .cookie(new jakarta.servlet.http.Cookie("refreshToken", "old-refresh")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("토큰 재발급 성공"))
+                .andDo(result1 -> {
+                    var cookies = result1.getResponse().getHeaders("Set-Cookie");
+                    assertThat(cookies.stream().anyMatch(c -> c.startsWith("accessToken="))).isTrue();
+                    assertThat(cookies.stream().anyMatch(c -> c.startsWith("refreshToken="))).isTrue();
+                });
+    }
+
+    @Test
+    void 토큰_갱신_실패_401() throws Exception {
+        // given
+        given(authService.refresh(any()))
+                .willThrow(new BusinessException(ErrorCode.UNAUTHORIZED, "Refresh Token이 만료되었습니다. 다시 로그인해주세요."));
+
+        // when & then
+        mockMvc.perform(post("/api/v1/auth/refresh"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401));
+    }
+
+    @Test
+    void 로그아웃_성공() throws Exception {
+        // when & then
+        mockMvc.perform(post("/api/v1/auth/logout")
+                        .cookie(new jakarta.servlet.http.Cookie("refreshToken", "some-token")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("로그아웃 성공"))
+                .andDo(result1 -> {
+                    var cookies = result1.getResponse().getHeaders("Set-Cookie");
+                    String accessCookie = cookies.stream()
+                            .filter(c -> c.startsWith("accessToken="))
+                            .findFirst().orElseThrow();
+                    assertThat(accessCookie).contains("Max-Age=0");
+
+                    String refreshCookie = cookies.stream()
+                            .filter(c -> c.startsWith("refreshToken="))
+                            .findFirst().orElseThrow();
+                    assertThat(refreshCookie).contains("Max-Age=0");
+                });
     }
 }

--- a/server/src/test/java/com/lectureq/server/auth/controller/AuthControllerTest.java
+++ b/server/src/test/java/com/lectureq/server/auth/controller/AuthControllerTest.java
@@ -1,15 +1,19 @@
 package com.lectureq.server.auth.controller;
 
+import com.lectureq.server.auth.AuthCookieFactory;
+import com.lectureq.server.auth.config.CookieProperties;
 import com.lectureq.server.auth.dto.LoginResponse;
 import com.lectureq.server.auth.service.AuthService;
 import com.lectureq.server.global.config.SecurityConfig;
 import com.lectureq.server.global.error.GlobalExceptionHandler;
 import com.lectureq.server.global.jwt.JwtAuthenticationEntryPoint;
 import com.lectureq.server.global.jwt.JwtAuthenticationFilter;
+import com.lectureq.server.global.jwt.JwtProperties;
 import com.lectureq.server.global.jwt.JwtProvider;
 import com.lectureq.server.user.entity.User;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
@@ -27,7 +31,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(AuthController.class)
-@Import({SecurityConfig.class, GlobalExceptionHandler.class, JwtAuthenticationFilter.class, JwtAuthenticationEntryPoint.class})
+@Import({SecurityConfig.class, GlobalExceptionHandler.class, JwtAuthenticationFilter.class, JwtAuthenticationEntryPoint.class, AuthCookieFactory.class})
+@EnableConfigurationProperties({CookieProperties.class, JwtProperties.class})
 class AuthControllerTest {
 
     @Autowired

--- a/server/src/test/java/com/lectureq/server/auth/controller/AuthControllerTest.java
+++ b/server/src/test/java/com/lectureq/server/auth/controller/AuthControllerTest.java
@@ -136,9 +136,13 @@ class AuthControllerTest {
 
     @Test
     void 로그아웃_성공() throws Exception {
+        // given
+        given(jwtProvider.validateToken("valid-access")).willReturn(true);
+        given(jwtProvider.getUserId("valid-access")).willReturn(1L);
+
         // when & then
         mockMvc.perform(post("/api/v1/auth/logout")
-                        .cookie(new jakarta.servlet.http.Cookie("refreshToken", "some-token")))
+                        .cookie(new jakarta.servlet.http.Cookie("accessToken", "valid-access")))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value(200))
                 .andExpect(jsonPath("$.message").value("로그아웃 성공"))
@@ -154,5 +158,12 @@ class AuthControllerTest {
                             .findFirst().orElseThrow();
                     assertThat(refreshCookie).contains("Max-Age=0");
                 });
+    }
+
+    @Test
+    void 로그아웃_인증없이_401() throws Exception {
+        // when & then (access token 없이 요청)
+        mockMvc.perform(post("/api/v1/auth/logout"))
+                .andExpect(status().isUnauthorized());
     }
 }

--- a/server/src/test/java/com/lectureq/server/auth/service/AuthServiceTest.java
+++ b/server/src/test/java/com/lectureq/server/auth/service/AuthServiceTest.java
@@ -2,6 +2,7 @@ package com.lectureq.server.auth.service;
 
 import com.lectureq.server.auth.entity.RefreshToken;
 import com.lectureq.server.auth.repository.RefreshTokenRepository;
+import com.lectureq.server.global.error.BusinessException;
 import com.lectureq.server.global.infra.kakao.KakaoClient;
 import com.lectureq.server.global.infra.kakao.KakaoTokenResponse;
 import com.lectureq.server.global.infra.kakao.KakaoUserResponse;
@@ -14,9 +15,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -105,5 +108,86 @@ class AuthServiceTest {
         assertThat(existingUser.getProfileImage()).isEqualTo("https://new-profile.jpg");
         verify(userRepository, never()).save(any(User.class));
         verify(refreshTokenRepository).deleteByUser(existingUser);
+    }
+
+    @Test
+    void 토큰_갱신_성공() {
+        // given
+        String oldRefreshToken = "old-refresh-token";
+        User user = User.builder()
+                .kakaoId("12345")
+                .nickname("홍길동")
+                .profileImage("https://profile.jpg")
+                .build();
+        RefreshToken storedToken = RefreshToken.builder()
+                .user(user)
+                .token(oldRefreshToken)
+                .expiredAt(LocalDateTime.now().plusDays(14))
+                .build();
+
+        given(jwtProvider.validateToken(oldRefreshToken)).willReturn(true);
+        given(refreshTokenRepository.findByToken(oldRefreshToken)).willReturn(Optional.of(storedToken));
+        given(jwtProvider.createAccessToken(any())).willReturn("new-access-token");
+        given(jwtProvider.createRefreshToken(any())).willReturn("new-refresh-token");
+        given(refreshTokenRepository.save(any(RefreshToken.class))).willReturn(null);
+
+        // when
+        AuthService.RefreshResult result = authService.refresh(oldRefreshToken);
+
+        // then
+        assertThat(result.accessToken()).isEqualTo("new-access-token");
+        assertThat(result.refreshToken()).isEqualTo("new-refresh-token");
+        verify(refreshTokenRepository).delete(storedToken);
+    }
+
+    @Test
+    void 토큰_갱신_실패_DB에_없는_토큰() {
+        // given
+        String invalidToken = "invalid-token";
+        given(jwtProvider.validateToken(invalidToken)).willReturn(true);
+        given(refreshTokenRepository.findByToken(invalidToken)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> authService.refresh(invalidToken))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    void 토큰_갱신_실패_null_토큰() {
+        // when & then
+        assertThatThrownBy(() -> authService.refresh(null))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    void 로그아웃_성공() {
+        // given
+        String refreshToken = "refresh-token";
+        User user = User.builder()
+                .kakaoId("12345")
+                .nickname("홍길동")
+                .profileImage("https://profile.jpg")
+                .build();
+        RefreshToken storedToken = RefreshToken.builder()
+                .user(user)
+                .token(refreshToken)
+                .expiredAt(LocalDateTime.now().plusDays(14))
+                .build();
+        given(refreshTokenRepository.findByToken(refreshToken)).willReturn(Optional.of(storedToken));
+
+        // when
+        authService.logout(refreshToken);
+
+        // then
+        verify(refreshTokenRepository).delete(storedToken);
+    }
+
+    @Test
+    void 로그아웃_토큰_없어도_성공() {
+        // when
+        authService.logout(null);
+
+        // then
+        verify(refreshTokenRepository, never()).findByToken(any());
     }
 }

--- a/server/src/test/java/com/lectureq/server/auth/service/AuthServiceTest.java
+++ b/server/src/test/java/com/lectureq/server/auth/service/AuthServiceTest.java
@@ -6,12 +6,13 @@ import com.lectureq.server.global.error.BusinessException;
 import com.lectureq.server.global.infra.kakao.KakaoClient;
 import com.lectureq.server.global.infra.kakao.KakaoTokenResponse;
 import com.lectureq.server.global.infra.kakao.KakaoUserResponse;
+import com.lectureq.server.global.jwt.JwtProperties;
 import com.lectureq.server.global.jwt.JwtProvider;
 import com.lectureq.server.user.entity.User;
 import com.lectureq.server.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -28,7 +29,6 @@ import static org.mockito.Mockito.never;
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
 
-    @InjectMocks
     private AuthService authService;
 
     @Mock
@@ -48,6 +48,12 @@ class AuthServiceTest {
 
     @Mock
     private KakaoUserResponse kakaoUserResponse;
+
+    @BeforeEach
+    void setUp() {
+        JwtProperties jwtProperties = new JwtProperties("secret", 1800000L, 1209600000L);
+        authService = new AuthService(kakaoClient, userRepository, refreshTokenRepository, jwtProvider, jwtProperties);
+    }
 
     @Test
     void 신규_사용자_로그인_성공() {
@@ -101,7 +107,7 @@ class AuthServiceTest {
         given(refreshTokenRepository.save(any(RefreshToken.class))).willReturn(null);
 
         // when
-        AuthService.LoginResult result = authService.login("test-code");
+        authService.login("test-code");
 
         // then
         assertThat(existingUser.getNickname()).isEqualTo("새닉네임");

--- a/server/src/test/java/com/lectureq/server/auth/service/AuthServiceTest.java
+++ b/server/src/test/java/com/lectureq/server/auth/service/AuthServiceTest.java
@@ -160,9 +160,9 @@ class AuthServiceTest {
     }
 
     @Test
-    void 로그아웃_성공() {
+    void 토큰_갱신_실패_DB_만료() {
         // given
-        String refreshToken = "refresh-token";
+        String expiredToken = "expired-refresh-token";
         User user = User.builder()
                 .kakaoId("12345")
                 .nickname("홍길동")
@@ -170,24 +170,47 @@ class AuthServiceTest {
                 .build();
         RefreshToken storedToken = RefreshToken.builder()
                 .user(user)
-                .token(refreshToken)
-                .expiredAt(LocalDateTime.now().plusDays(14))
+                .token(expiredToken)
+                .expiredAt(LocalDateTime.now().minusMinutes(1))
                 .build();
-        given(refreshTokenRepository.findByToken(refreshToken)).willReturn(Optional.of(storedToken));
 
-        // when
-        authService.logout(refreshToken);
+        given(jwtProvider.validateToken(expiredToken)).willReturn(true);
+        given(refreshTokenRepository.findByToken(expiredToken)).willReturn(Optional.of(storedToken));
 
-        // then
+        // when & then
+        assertThatThrownBy(() -> authService.refresh(expiredToken))
+                .isInstanceOf(BusinessException.class);
         verify(refreshTokenRepository).delete(storedToken);
     }
 
     @Test
-    void 로그아웃_토큰_없어도_성공() {
+    void 로그아웃_성공() {
+        // given
+        Long userId = 1L;
+        User user = User.builder()
+                .kakaoId("12345")
+                .nickname("홍길동")
+                .profileImage("https://profile.jpg")
+                .build();
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
         // when
-        authService.logout(null);
+        authService.logout(userId);
 
         // then
-        verify(refreshTokenRepository, never()).findByToken(any());
+        verify(refreshTokenRepository).deleteByUser(user);
+    }
+
+    @Test
+    void 로그아웃_탈퇴된_사용자() {
+        // given
+        Long userId = 999L;
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+        // when
+        authService.logout(userId);
+
+        // then
+        verify(refreshTokenRepository, never()).deleteByUser(any());
     }
 }

--- a/server/src/test/java/com/lectureq/server/global/error/GlobalExceptionHandlerTest.java
+++ b/server/src/test/java/com/lectureq/server/global/error/GlobalExceptionHandlerTest.java
@@ -34,6 +34,9 @@ class GlobalExceptionHandlerTest {
     @MockitoBean
     private AuthService authService;
 
+    @MockitoBean
+    private com.lectureq.server.global.jwt.JwtProvider jwtProvider;
+
     @Test
     void businessException_default_message() throws Exception {
         mockMvc.perform(get("/test/business-default"))

--- a/server/src/test/java/com/lectureq/server/global/error/GlobalExceptionHandlerTest.java
+++ b/server/src/test/java/com/lectureq/server/global/error/GlobalExceptionHandlerTest.java
@@ -23,7 +23,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest
+@WebMvcTest(controllers = GlobalExceptionHandlerTest.TestController.class)
 @Import({GlobalExceptionHandler.class, GlobalExceptionHandlerTest.TestController.class})
 @WithMockUser
 class GlobalExceptionHandlerTest {

--- a/server/src/test/java/com/lectureq/server/global/jwt/JwtAuthenticationFilterTest.java
+++ b/server/src/test/java/com/lectureq/server/global/jwt/JwtAuthenticationFilterTest.java
@@ -1,0 +1,65 @@
+package com.lectureq.server.global.jwt;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import jakarta.servlet.http.Cookie;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class JwtAuthenticationFilterTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Test
+    void 유효한_토큰으로_보호된_API_접근_인증_통과() throws Exception {
+        String token = jwtProvider.createAccessToken(1L);
+
+        int status = mockMvc.perform(get("/api/v1/users/me")
+                        .cookie(new Cookie("accessToken", token)))
+                .andReturn().getResponse().getStatus();
+
+        assertThat(status).isNotEqualTo(401);
+    }
+
+    @Test
+    void 토큰_없이_보호된_API_접근_401() throws Exception {
+        mockMvc.perform(get("/api/v1/users/me"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.message").value("인증이 필요합니다."));
+    }
+
+    @Test
+    void 만료된_토큰으로_보호된_API_접근_401() throws Exception {
+        JwtProvider shortLived = new JwtProvider(
+                "dGVzdC1zZWNyZXQta2V5LW11c3QtYmUtYXQtbGVhc3QtMzItYnl0ZXMtbG9uZw==", 0, 0);
+        String expired = shortLived.createAccessToken(1L);
+
+        mockMvc.perform(get("/api/v1/users/me")
+                        .cookie(new Cookie("accessToken", expired)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void permitAll_경로는_토큰_없이_접근_가능() throws Exception {
+        int status = mockMvc.perform(post("/api/v1/auth/logout"))
+                .andReturn().getResponse().getStatus();
+
+        assertThat(status).isNotEqualTo(401);
+    }
+}

--- a/server/src/test/java/com/lectureq/server/global/jwt/JwtAuthenticationFilterTest.java
+++ b/server/src/test/java/com/lectureq/server/global/jwt/JwtAuthenticationFilterTest.java
@@ -46,8 +46,9 @@ class JwtAuthenticationFilterTest {
 
     @Test
     void 만료된_토큰으로_보호된_API_접근_401() throws Exception {
-        JwtProvider shortLived = new JwtProvider(
-                "dGVzdC1zZWNyZXQta2V5LW11c3QtYmUtYXQtbGVhc3QtMzItYnl0ZXMtbG9uZw==", 0, 0);
+        JwtProvider shortLived = new JwtProvider(new JwtProperties(
+                "dGVzdC1zZWNyZXQta2V5LW11c3QtYmUtYXQtbGVhc3QtMzItYnl0ZXMtbG9uZw==", 0, 0));
+        shortLived.init();
         String expired = shortLived.createAccessToken(1L);
 
         mockMvc.perform(get("/api/v1/users/me")

--- a/server/src/test/java/com/lectureq/server/global/jwt/JwtAuthenticationFilterTest.java
+++ b/server/src/test/java/com/lectureq/server/global/jwt/JwtAuthenticationFilterTest.java
@@ -57,9 +57,12 @@ class JwtAuthenticationFilterTest {
 
     @Test
     void permitAll_경로는_토큰_없이_접근_가능() throws Exception {
-        int status = mockMvc.perform(post("/api/v1/auth/logout"))
+        int status = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType("application/json")
+                        .content("{\"code\": \"\"}"))
                 .andReturn().getResponse().getStatus();
 
+        // 인증 단에서는 막히지 않고, 검증 단에서 400 반환됨
         assertThat(status).isNotEqualTo(401);
     }
 }

--- a/server/src/test/java/com/lectureq/server/global/jwt/JwtProviderTest.java
+++ b/server/src/test/java/com/lectureq/server/global/jwt/JwtProviderTest.java
@@ -1,0 +1,44 @@
+package com.lectureq.server.global.jwt;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JwtProviderTest {
+
+    private JwtProvider jwtProvider;
+
+    @BeforeEach
+    void setUp() {
+        String secret = "dGVzdC1zZWNyZXQta2V5LW11c3QtYmUtYXQtbGVhc3QtMzItYnl0ZXMtbG9uZw==";
+        jwtProvider = new JwtProvider(secret, 1800000, 1209600000);
+    }
+
+    @Test
+    void 유효한_토큰_검증_성공() {
+        String token = jwtProvider.createAccessToken(1L);
+        assertThat(jwtProvider.validateToken(token)).isTrue();
+    }
+
+    @Test
+    void 만료된_토큰_검증_실패() {
+        JwtProvider shortLived = new JwtProvider(
+                "dGVzdC1zZWNyZXQta2V5LW11c3QtYmUtYXQtbGVhc3QtMzItYnl0ZXMtbG9uZw==", 0, 0);
+        String token = shortLived.createAccessToken(1L);
+        assertThat(jwtProvider.validateToken(token)).isFalse();
+    }
+
+    @Test
+    void 변조된_토큰_검증_실패() {
+        String token = jwtProvider.createAccessToken(1L);
+        String tampered = token + "tampered";
+        assertThat(jwtProvider.validateToken(tampered)).isFalse();
+    }
+
+    @Test
+    void 토큰에서_userId_추출() {
+        String token = jwtProvider.createAccessToken(42L);
+        assertThat(jwtProvider.getUserId(token)).isEqualTo(42L);
+    }
+}

--- a/server/src/test/java/com/lectureq/server/global/jwt/JwtProviderTest.java
+++ b/server/src/test/java/com/lectureq/server/global/jwt/JwtProviderTest.java
@@ -7,12 +7,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class JwtProviderTest {
 
+    private static final String SECRET = "dGVzdC1zZWNyZXQta2V5LW11c3QtYmUtYXQtbGVhc3QtMzItYnl0ZXMtbG9uZw==";
+
     private JwtProvider jwtProvider;
 
     @BeforeEach
     void setUp() {
-        String secret = "dGVzdC1zZWNyZXQta2V5LW11c3QtYmUtYXQtbGVhc3QtMzItYnl0ZXMtbG9uZw==";
-        jwtProvider = new JwtProvider(secret, 1800000, 1209600000);
+        jwtProvider = createProvider(1800000, 1209600000);
+    }
+
+    private JwtProvider createProvider(long accessExpiration, long refreshExpiration) {
+        JwtProvider provider = new JwtProvider(new JwtProperties(SECRET, accessExpiration, refreshExpiration));
+        provider.init();
+        return provider;
     }
 
     @Test
@@ -23,8 +30,7 @@ class JwtProviderTest {
 
     @Test
     void 만료된_토큰_검증_실패() {
-        JwtProvider shortLived = new JwtProvider(
-                "dGVzdC1zZWNyZXQta2V5LW11c3QtYmUtYXQtbGVhc3QtMzItYnl0ZXMtbG9uZw==", 0, 0);
+        JwtProvider shortLived = createProvider(0, 0);
         String token = shortLived.createAccessToken(1L);
         assertThat(jwtProvider.validateToken(token)).isFalse();
     }

--- a/server/src/test/resources/application-test.yml
+++ b/server/src/test/resources/application-test.yml
@@ -11,6 +11,9 @@ spring:
     properties:
       hibernate:
         format_sql: true
+  sql:
+    init:
+      mode: never
 
 jwt:
   secret: dGVzdC1zZWNyZXQta2V5LW11c3QtYmUtYXQtbGVhc3QtMzItYnl0ZXMtbG9uZw==


### PR DESCRIPTION
## 변경 사항
- POST /auth/refresh (Token Rotation)
- POST /auth/logout (DB 삭제 + 쿠키 만료)
- JWT 인증 필터

## 테스트
- Refresh Token으로 새 토큰 발급 성공
- 만료된 Refresh Token → 401
- 로그아웃 후 Refresh Token DB에서 삭제 확인
- 인증 필요 API에 토큰 없이 요청 → 401

closes #62